### PR TITLE
Add a user friendly syntax to template render

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "spatie/invade": "^1.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e6042849aefa86348ecf0eca882720f",
+    "content-hash": "8a8c4bd76670abd3cd426c2a14df9a3a",
     "packages": [
         {
             "name": "akaunting/laravel-money",
@@ -10054,6 +10054,72 @@
                 }
             ],
             "time": "2021-11-09T10:57:15+00:00"
+        },
+        {
+            "name": "spatie/invade",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/invade.git",
+                "reference": "d0a9c895a96152549d478a7e3420e19039eef038"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/invade/zipball/d0a9c895a96152549d478a7e3420e19039eef038",
+                "reference": "d0a9c895a96152549d478a7e3420e19039eef038",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "pestphp/pest": "^1.20",
+                "phpstan/phpstan": "^1.4",
+                "spatie/ray": "^1.28"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "phpstan-extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Spatie\\Invade\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A PHP function to work with private properties and methods",
+            "homepage": "https://github.com/spatie/invade",
+            "keywords": [
+                "invade",
+                "spatie"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/invade/tree/1.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-07-05T09:31:00+00:00"
         },
         {
             "name": "spatie/laravel-ray",

--- a/src/Actions/Templates/Render.php
+++ b/src/Actions/Templates/Render.php
@@ -25,8 +25,8 @@ class Render extends Action
 
         $latte = new Latte\Engine();
         $latte->setLoader(new Latte\Loaders\StringLoader([
-            $mainFileName => $mainFileContent,
-            $layoutFileName => $template->layout?->content,
+            $mainFileName => $this->parse($mainFileContent),
+            $layoutFileName => $this->parse($template->layout?->content ?: ''),
         ]));
 
         return $latte->renderToString($mainFileName, $variables);

--- a/src/Actions/Templates/Render.php
+++ b/src/Actions/Templates/Render.php
@@ -2,6 +2,8 @@
 
 namespace MailCarrier\Actions\Templates;
 
+use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use Latte;
 use MailCarrier\Actions\Action;
 use MailCarrier\Models\Template;
@@ -28,5 +30,56 @@ class Render extends Action
         ]));
 
         return $latte->renderToString($mainFileName, $variables);
+    }
+
+    /**
+     * Parse the template syntax.
+     */
+    protected function parse(string $template): string
+    {
+        preg_match_all('/{{(.*?)}}/', $template, $variables);
+
+        foreach ($variables[1] ?? [] as $variable) {
+            $realVariable = Str::of($variable)
+                ->before('|')
+                ->trim()
+                ->toString();
+
+            // Extract filters to reapply them when replacing the variable
+            $variableFilters = '';
+
+            if (str_contains($variable, '|')) {
+                $variableFilters = Str::of($variable)
+                    ->after('|')
+                    ->trim()
+                    ->whenNotEmpty(fn (Stringable $str) => $str->prepend('|'))
+                    ->toString();
+            }
+
+            // Transform variable if is an array/object
+            if (str_contains($realVariable, '.')) {
+                // Transform everything after the actual variable name into an array-based index
+                $indexBasedVariable = Str::of($realVariable)
+                    ->after('.')
+                    ->explode('.')
+                    ->map(fn (string $value) => is_numeric($value) ? "[$value]" : "['$value']")
+                    ->join('');
+
+                // Prepend the actual variable name
+                $realVariable = Str::before($realVariable, '.') . $indexBasedVariable;
+            }
+
+            if (!str_starts_with($realVariable, '$')) {
+                $realVariable = '$' . $realVariable;
+            }
+
+            $template = str_replace(
+                '{{' . $variable . '}}',
+                '{' . $realVariable . $variableFilters . '}',
+                $template
+            );
+        }
+
+        return $template;
     }
 }

--- a/tests/Unit/Template/RenderTest.php
+++ b/tests/Unit/Template/RenderTest.php
@@ -14,21 +14,21 @@ it('transforms plain variables', function () {
 
 it('transforms direct access to array properties', function () {
     $result = invade(Render::resolve())->parse(<<<TEMPLATE
-        {{foo['bar']}} {{\$bar['baz']}} {{foo['bar']['baz']}} {{bar['baz']}} {{bar[0]}}
+        {{foo['bar']}} {{\$bar['baz']}} {{foo['bar']['baz']}} {{bar['baz']}} {{bar[0]}} {{bar[0][1]}}
     TEMPLATE);
 
     expect($result)->toBe(<<<TEMPLATE
-        {\$foo['bar']} {\$bar['baz']} {\$foo['bar']['baz']} {\$bar['baz']} {\$bar[0]}
+        {\$foo['bar']} {\$bar['baz']} {\$foo['bar']['baz']} {\$bar['baz']} {\$bar[0]} {\$bar[0][1]}
     TEMPLATE);
 });
 
 it('transforms dot notation access to array properties', function () {
     $result = invade(Render::resolve())->parse(<<<TEMPLATE
-        {{foo.bar}} {{\$bar.baz}} {{foo['bar']['baz']}} {{bar.baz}} {{foo[0].bar}} {{foo.0.bar.baz}}
+        {{foo.bar}} {{\$bar.baz}} {{foo['bar']['baz']}} {{bar.baz}} {{foo[0].bar}} {{foo.0.bar.baz}} {{foo.0.1.bar.2.baz}}
     TEMPLATE);
 
     expect($result)->toBe(<<<TEMPLATE
-        {\$foo['bar']} {\$bar['baz']} {\$foo['bar']['baz']} {\$bar['baz']} {\$foo[0]['bar']} {\$foo[0]['bar']['baz']}
+        {\$foo['bar']} {\$bar['baz']} {\$foo['bar']['baz']} {\$bar['baz']} {\$foo[0]['bar']} {\$foo[0]['bar']['baz']} {\$foo[0][1]['bar'][2]['baz']}
     TEMPLATE);
 });
 

--- a/tests/Unit/Template/RenderTest.php
+++ b/tests/Unit/Template/RenderTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use MailCarrier\Actions\Templates\Render;
+
+it('transforms plain variables', function () {
+    $result = invade(Render::resolve())->parse(<<<TEMPLATE
+        {{foo}} {{\$bar}} {{foo}} {{bar}}
+    TEMPLATE);
+
+    expect($result)->toBe(<<<TEMPLATE
+        {\$foo} {\$bar} {\$foo} {\$bar}
+    TEMPLATE);
+});
+
+it('transforms direct access to array properties', function () {
+    $result = invade(Render::resolve())->parse(<<<TEMPLATE
+        {{foo['bar']}} {{\$bar['baz']}} {{foo['bar']['baz']}} {{bar['baz']}} {{bar[0]}}
+    TEMPLATE);
+
+    expect($result)->toBe(<<<TEMPLATE
+        {\$foo['bar']} {\$bar['baz']} {\$foo['bar']['baz']} {\$bar['baz']} {\$bar[0]}
+    TEMPLATE);
+});
+
+it('transforms dot notation access to array properties', function () {
+    $result = invade(Render::resolve())->parse(<<<TEMPLATE
+        {{foo.bar}} {{\$bar.baz}} {{foo['bar']['baz']}} {{bar.baz}} {{foo[0].bar}} {{foo.0.bar.baz}}
+    TEMPLATE);
+
+    expect($result)->toBe(<<<TEMPLATE
+        {\$foo['bar']} {\$bar['baz']} {\$foo['bar']['baz']} {\$bar['baz']} {\$foo[0]['bar']} {\$foo[0]['bar']['baz']}
+    TEMPLATE);
+});
+
+it('handles variables with spaces around brackets', function () {
+    $result = invade(Render::resolve())->parse(<<<TEMPLATE
+        {{ foo.bar }} {{ \$bar.baz }} {{ foo['bar']['baz'] }} {{foo.bar}} {{ foo }}
+    TEMPLATE);
+
+    expect($result)->toBe(<<<TEMPLATE
+        {\$foo['bar']} {\$bar['baz']} {\$foo['bar']['baz']} {\$foo['bar']} {\$foo}
+    TEMPLATE);
+});
+
+it('respects the engine filters', function () {
+    $result = invade(Render::resolve())->parse(<<<TEMPLATE
+        {{ foo.bar|upper }} {{\$bar.baz|lower}} {{foo['bar']['baz']|upper}} {{ bar|upper|reverse }} {{foo|lower|reverse}}
+    TEMPLATE);
+
+    expect($result)->toBe(<<<TEMPLATE
+        {\$foo['bar']|upper} {\$bar['baz']|lower} {\$foo['bar']['baz']|upper} {\$bar|upper|reverse} {\$foo|lower|reverse}
+    TEMPLATE);
+});

--- a/tests/Unit/Template/RenderTest.php
+++ b/tests/Unit/Template/RenderTest.php
@@ -3,51 +3,51 @@
 use MailCarrier\Actions\Templates\Render;
 
 it('transforms plain variables', function () {
-    $result = invade(Render::resolve())->parse(<<<TEMPLATE
-        {{foo}} {{\$bar}} {{foo}} {{bar}}
+    $result = invade(Render::resolve())->parse(<<<'TEMPLATE'
+        {{foo}} {{$bar}} {{foo}} {{bar}}
     TEMPLATE);
 
-    expect($result)->toBe(<<<TEMPLATE
-        {\$foo} {\$bar} {\$foo} {\$bar}
+    expect($result)->toBe(<<<'TEMPLATE'
+        {$foo} {$bar} {$foo} {$bar}
     TEMPLATE);
 });
 
 it('transforms direct access to array properties', function () {
-    $result = invade(Render::resolve())->parse(<<<TEMPLATE
-        {{foo['bar']}} {{\$bar['baz']}} {{foo['bar']['baz']}} {{bar['baz']}} {{bar[0]}} {{bar[0][1]}}
+    $result = invade(Render::resolve())->parse(<<<'TEMPLATE'
+        {{foo['bar']}} {{$bar['baz']}} {{foo['bar']['baz']}} {{bar['baz']}} {{bar[0]}} {{bar[0][1]}}
     TEMPLATE);
 
-    expect($result)->toBe(<<<TEMPLATE
-        {\$foo['bar']} {\$bar['baz']} {\$foo['bar']['baz']} {\$bar['baz']} {\$bar[0]} {\$bar[0][1]}
+    expect($result)->toBe(<<<'TEMPLATE'
+        {$foo['bar']} {$bar['baz']} {$foo['bar']['baz']} {$bar['baz']} {$bar[0]} {$bar[0][1]}
     TEMPLATE);
 });
 
 it('transforms dot notation access to array properties', function () {
-    $result = invade(Render::resolve())->parse(<<<TEMPLATE
-        {{foo.bar}} {{\$bar.baz}} {{foo['bar']['baz']}} {{bar.baz}} {{foo[0].bar}} {{foo.0.bar.baz}} {{foo.0.1.bar.2.baz}}
+    $result = invade(Render::resolve())->parse(<<<'TEMPLATE'
+        {{foo.bar}} {{$bar.baz}} {{foo['bar']['baz']}} {{bar.baz}} {{foo[0].bar}} {{foo.0.bar.baz}} {{foo.0.1.bar.2.baz}}
     TEMPLATE);
 
-    expect($result)->toBe(<<<TEMPLATE
-        {\$foo['bar']} {\$bar['baz']} {\$foo['bar']['baz']} {\$bar['baz']} {\$foo[0]['bar']} {\$foo[0]['bar']['baz']} {\$foo[0][1]['bar'][2]['baz']}
+    expect($result)->toBe(<<<'TEMPLATE'
+        {$foo['bar']} {$bar['baz']} {$foo['bar']['baz']} {$bar['baz']} {$foo[0]['bar']} {$foo[0]['bar']['baz']} {$foo[0][1]['bar'][2]['baz']}
     TEMPLATE);
 });
 
 it('handles variables with spaces around brackets', function () {
-    $result = invade(Render::resolve())->parse(<<<TEMPLATE
-        {{ foo.bar }} {{ \$bar.baz }} {{ foo['bar']['baz'] }} {{foo.bar}} {{ foo }}
+    $result = invade(Render::resolve())->parse(<<<'TEMPLATE'
+        {{ foo.bar }} {{ $bar.baz }} {{ foo['bar']['baz'] }} {{foo.bar}} {{ foo }}
     TEMPLATE);
 
-    expect($result)->toBe(<<<TEMPLATE
-        {\$foo['bar']} {\$bar['baz']} {\$foo['bar']['baz']} {\$foo['bar']} {\$foo}
+    expect($result)->toBe(<<<'TEMPLATE'
+        {$foo['bar']} {$bar['baz']} {$foo['bar']['baz']} {$foo['bar']} {$foo}
     TEMPLATE);
 });
 
 it('respects the engine filters', function () {
-    $result = invade(Render::resolve())->parse(<<<TEMPLATE
-        {{ foo.bar|upper }} {{\$bar.baz|lower}} {{foo['bar']['baz']|upper}} {{ bar|upper|reverse }} {{foo|lower|reverse}}
+    $result = invade(Render::resolve())->parse(<<<'TEMPLATE'
+        {{ foo.bar|upper }} {{$bar.baz|lower}} {{foo['bar']['baz']|upper}} {{ bar|upper|reverse }} {{foo|lower|reverse}}
     TEMPLATE);
 
-    expect($result)->toBe(<<<TEMPLATE
-        {\$foo['bar']|upper} {\$bar['baz']|lower} {\$foo['bar']['baz']|upper} {\$bar|upper|reverse} {\$foo|lower|reverse}
+    expect($result)->toBe(<<<'TEMPLATE'
+        {$foo['bar']|upper} {$bar['baz']|lower} {$foo['bar']['baz']|upper} {$bar|upper|reverse} {$foo|lower|reverse}
     TEMPLATE);
 });


### PR DESCRIPTION
**New syntax**

```
{{ foo }}
{{ foo.bar }}
{{ foo.0.bar }}
{{ foo[0].bar }}
{{ foo|upper }}
```

It will be transformed into:

```
{$foo}
{$foo['bar']}
{$foo[0]['bar']}
{$foo[0]['bar']}
{$foo|upper}
```