### PR TITLE
[Feature] `beforeSending` sync middleware

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -5,5 +5,5 @@ use MailCarrier\Http\Controllers\MailCarrierController;
 use MailCarrier\Http\Middleware\ForceJsonRequest;
 
 Route::prefix('api')->middleware(ForceJsonRequest::class)->group(function () {
-    Route::post('send', [MailCarrierController::class, 'send'])->name('send');
+    Route::post('send', [MailCarrierController::class, 'send'])->name('mailcarrier.send');
 });

--- a/src/Actions/SendMail.php
+++ b/src/Actions/SendMail.php
@@ -2,7 +2,6 @@
 
 namespace MailCarrier\Actions;
 
-use Exception;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
@@ -144,6 +143,10 @@ class SendMail extends Action
             report($exception);
 
             return;
+        }
+
+        if ($beforeSendingMiddleware = MailCarrier::getBeforeSendingMiddleware()) {
+            $beforeSendingMiddleware($genericMailDto);
         }
 
         if ($sendingMiddleware = MailCarrier::getSendingMiddleware()) {

--- a/src/Facades/MailCarrier.php
+++ b/src/Facades/MailCarrier.php
@@ -6,7 +6,9 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static void sending(\Closure $callback)
+ * @method static void beforeSending(\Closure $callback)
  * @method static \Closure|null getSendingMiddleware()
+ * @method static \Closure|null getBeforeSendingMiddleware()
  * @method static void authorizeSocialAuth(\Closure $callback)
  * @method static void validateSocialAuth(\Laravel\Socialite\AbstractUser $user)
  * @method static string|null getSocialAuthDriver()

--- a/src/Http/Controllers/MailCarrierController.php
+++ b/src/Http/Controllers/MailCarrierController.php
@@ -16,6 +16,7 @@ use MailCarrier\Exceptions\MissingVariableException;
 use MailCarrier\Http\ApiResponse;
 use MailCarrier\Http\Requests\SendMailRequest;
 use MailCarrier\Models\Attachment;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class MailCarrierController extends Controller
 {
@@ -54,7 +55,7 @@ class MailCarrierController extends Controller
             return ApiResponse::error(
                 ApiErrorKey::UnexpectedError->value,
                 $e->getMessage(),
-                JsonResponse::HTTP_INTERNAL_SERVER_ERROR
+                $e instanceof HttpException ? $e->getStatusCode() : Response::HTTP_INTERNAL_SERVER_ERROR
             );
         }
 

--- a/src/Http/Controllers/MailCarrierController.php
+++ b/src/Http/Controllers/MailCarrierController.php
@@ -59,7 +59,7 @@ class MailCarrierController extends Controller
             );
         }
 
-        return ApiResponse::success(httpStatus: JsonResponse::HTTP_NO_CONTENT);
+        return ApiResponse::success();
     }
 
     /**

--- a/src/MailCarrierManager.php
+++ b/src/MailCarrierManager.php
@@ -15,6 +15,8 @@ class MailCarrierManager
 {
     protected ?Closure $sendingMiddleware = null;
 
+    protected ?Closure $beforeSendingMiddleware = null;
+
     protected ?Closure $socialAuthGate = null;
 
     /**
@@ -25,6 +27,16 @@ class MailCarrierManager
     public function sending(Closure $callback): void
     {
         $this->sendingMiddleware = $callback;
+    }
+
+    /**
+     * Invoke a custom callback before a sending a mail (sync).
+     *
+     * @param Closure(\MailCarrier\Dto\GenericMailDto $mail): void $callback
+     */
+    public function beforeSending(Closure $callback): void
+    {
+        $this->beforeSendingMiddleware = $callback;
     }
 
     /**
@@ -57,6 +69,14 @@ class MailCarrierManager
     public function getSendingMiddleware(): ?Closure
     {
         return $this->sendingMiddleware;
+    }
+
+    /**
+     * Get the sending middleware callback.
+     */
+    public function getBeforeSendingMiddleware(): ?Closure
+    {
+        return $this->beforeSendingMiddleware;
     }
 
     /**

--- a/src/Providers/stubs/AppServiceProvider.php.stub
+++ b/src/Providers/stubs/AppServiceProvider.php.stub
@@ -13,6 +13,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        MailCarrier::beforeSending(function (GenericMailDto $mail): void {
+            return;
+        });
+
         MailCarrier::sending(function (GenericMailDto $mail, \Closure $next): void {
             $next();
         });


### PR DESCRIPTION
This PR adds a new `beforeSending` middleware callback that runs sync before the email (and log) has been created.
It also contains some other fixes, such as:

- Rename the `send` route name
- If an HttpException has been thrown within the `send` endpoint, return that HTTP status code